### PR TITLE
Fix and optimize TDMS_TimeSecond

### DIFF
--- a/config/TDMS_config.h
+++ b/config/TDMS_config.h
@@ -29,14 +29,6 @@ extern "C" {
 #define TDMS_CONFIG_MAX_GROUP_OF_FILE       4
 #define TDMS_CONFIG_MAX_CHANNEL_OF_GROUP    8
 
-/**
- * @brief  Determines system Endianness
- *         - 0: little-endian
- *         - 1: big-endian
- */
-#define TDMS_CONFIG_SYSTEM_ENDIANNESS       0
-
-
 
 #ifdef __cplusplus
 }

--- a/src/TDMS.c
+++ b/src/TDMS.c
@@ -246,21 +246,9 @@ TDMS_GenerateChannelPath(TDMS_Group_t *Group,
 static uint8_t
 TDMS_SaveDataLittleEndian32(uint8_t *data, uint32_t value)
 {
-  typedef union
-  {
-    uint32_t  Uint32Value;
-    uint8_t   Uint8Value[4];
-  } U32toU8_t;
-
-  U32toU8_t Buffer = {.Uint32Value = value,};
-  
   for (uint8_t i = 0; i < 4; i++)
   {
-#if (TDMS_CONFIG_SYSTEM_ENDIANNESS == 0)
-    data[i] = Buffer.Uint8Value[i];
-#else
-    data[i] = Buffer.Uint8Value[4-i];
-#endif
+    data[i] = value >> (8*i);
   }
   
   return 4;
@@ -276,21 +264,9 @@ TDMS_SaveDataLittleEndian32(uint8_t *data, uint32_t value)
 static uint8_t
 TDMS_SaveDataLittleEndian64(uint8_t *data, uint64_t value)
 {
-  typedef union
-  {
-    uint64_t  Uint64Value;
-    uint8_t   Uint8Value[8];
-  } U64toU8_t;
-  
-  U64toU8_t Buffer = {.Uint64Value = value,};
-
   for (uint8_t i = 0; i < 8; i++)
   {
-#if (TDMS_CONFIG_SYSTEM_ENDIANNESS == 0)
-    data[i] = Buffer.Uint8Value[i];
-#else
-    data[i] = Buffer.Uint8Value[8-i];
-#endif
+    data[i] = value >> (8*i);
   }
 
   return 8;

--- a/src/TDMS.c
+++ b/src/TDMS.c
@@ -81,7 +81,7 @@
 /**
  * @brief  Specify the number of days in the month
  *         daysPerMonth[0][]: non leap year
- *         daysPerMonth[0][]: leap year
+ *         daysPerMonth[1][]: leap year
  */ 
 const int8_t
     daysPerMonth[2][13] = {{-1, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31},
@@ -147,8 +147,8 @@ const uint8_t dataTypeLength[TDMS_DataType_MAX] =
 /**
  * @brief  Calculate number of days between LabVIEW Timestamp base and inserted
  *         date
- * @param  Day: Day number (0 to 31)
- * @param  Month: Month number (0 to 12)
+ * @param  Day: Day number (1 to 31)
+ * @param  Month: Month number (1 to 12)
  * @param  Year: Year number (1904 to ...)
  * @retval Number of days
  */
@@ -168,7 +168,7 @@ TDMS_DateDef(uint8_t Day, uint8_t Month, uint16_t Year)
       for (m = Month; m >= 1; m--)
       {
         if (m == Month)
-          total_days += Day;
+          total_days += Day - 1;
         else
           total_days += daysPerMonth[leapYear(y)][m];
       }
@@ -177,10 +177,7 @@ TDMS_DateDef(uint8_t Day, uint8_t Month, uint16_t Year)
     {
       for (m = 12; m >= BaseMonth; m--)
       {
-        if (m == BaseMonth)
-          total_days += daysPerMonth[leapYear(y)][m] - BaseDay;
-        else
-          total_days += daysPerMonth[leapYear(y)][m];
+        total_days += daysPerMonth[leapYear(y)][m];
       }
     }
     else

--- a/src/TDMS.c
+++ b/src/TDMS.c
@@ -182,10 +182,7 @@ TDMS_DateDef(uint8_t Day, uint8_t Month, uint16_t Year)
     }
     else
     {
-      for (m = 12; m >= 1; m--)
-      {
-        total_days += daysPerMonth[leapYear(y)][m];
-      }
+      total_days += leapYear(y) ? 366 : 365;
     }
   }
 

--- a/src/TDMS.c
+++ b/src/TDMS.c
@@ -278,7 +278,7 @@ TDMS_SaveDataLittleEndian64(uint8_t *data, uint64_t value)
 {
   typedef union
   {
-    uint32_t  Uint64Value;
+    uint64_t  Uint64Value;
     uint8_t   Uint8Value[8];
   } U64toU8_t;
   

--- a/src/include/TDMS.h
+++ b/src/include/TDMS.h
@@ -39,10 +39,6 @@ extern "C" {
   #define TDMS_CONFIG_MAX_CHANNEL_OF_GROUP  8
 #endif
 
-#ifndef TDMS_CONFIG_SYSTEM_ENDIANNESS
-  #define TDMS_CONFIG_SYSTEM_ENDIANNESS  0
-#endif
-
 
 /* Exported Data Types ----------------------------------------------------------*/
 


### PR DESCRIPTION
Fix bug in `TDMS_TimeSecond` where year 1904 started counting days from 0, but other years from 1. Now holds that `TDMS_TimeSecond(1904, 1, 1, 0, 0, 0) == 0`.

Sadly, the official docs [LabVIEW Timestamp Overview](https://www.ni.com/en/support/documentation/supplemental/08/labview-timestamp-overview.html) have an incorrect time for 2002-01-01 00:00:00, it should be `TDMS_TimeSecond(2002, 1, 1, 0, 0, 0) == 3092688000`, not 3092601600. This is discussed in [this forum post](https://forums.ni.com/t5/LabVIEW/going-deep-into-timestamp/m-p/3234292).

Additionally optimize full years. Instead of looping over all months, directly add 365 days (or 366 for leap year). This is roughly 10x speedup.